### PR TITLE
Change of default priority of match method. #1

### DIFF
--- a/lib/HTTP/AcceptLanguage.pm
+++ b/lib/HTTP/AcceptLanguage.pm
@@ -4,6 +4,8 @@ use warnings;
 use 5.008_005;
 our $VERSION = '0.01';
 
+our $MATCH_PRIORITY_0_01_STYLE;
+
 my $LANGUAGE_RANGE = qr/(?:[A-Za-z0-9]{1,8}(?:-[A-Za-z0-9]{1,8})*|\*)/;
 my $QVALUE         = qr/(?:0(?:\.[0-9]{0,3})?|1(?:\.0{0,3})?)/;
 
@@ -79,12 +81,13 @@ sub match {
 
     $self->{sorted_parsed_header} ||= [ sort { $b->{quality} <=> $a->{quality} } @{ $self->{parsed_header} } ];
 
-    # If language-quality is the same, is a priority order of the @languages
+    # If language-quality has the same value, is a priority order of the $self->{sorted_parsed_header}.
+    # If you set $MATCH_PRIORITY_0_01_STYLE=1, takes is a priority order of the @languages
     my %header_tags;
     my %header_primary_tags;
     my $current_quality = 0;
     for my $language (@{ $self->{sorted_parsed_header} }) {
-        if ($current_quality != $language->{quality}) {
+        if (!$MATCH_PRIORITY_0_01_STYLE || $current_quality != $language->{quality}) {
             if (scalar(%header_tags)) {
                 # RFC give priority to full match.
                 for my $tag (@normlized_languages) {

--- a/t/02_match_0_01_compat.t
+++ b/t/02_match_0_01_compat.t
@@ -4,6 +4,10 @@ use Test::More;
 
 use HTTP::AcceptLanguage;
 
+# This test case checks 0.01 compatibility mode.
+# Test case is taken from version 0.01 test suite.
+local $HTTP::AcceptLanguage::MATCH_PRIORITY_0_01_STYLE = 1;
+
 subtest 'empty' => sub {
     subtest 'undef' => sub {
         my $parser = HTTP::AcceptLanguage->new;

--- a/t/03_nonq_priority.t
+++ b/t/03_nonq_priority.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use HTTP::AcceptLanguage;
+
+# Priority detection for language tags that does not have q= parameters.
+
+subtest 'new spec' => sub {
+    my $accept_language = HTTP::AcceptLanguage->new('en, da');
+    is $accept_language->match(qw/ da en /), 'en';
+    is $accept_language->match(qw/ en da /), 'en';
+};
+
+subtest 'old spec' => sub {
+    local $HTTP::AcceptLanguage::MATCH_PRIORITY_0_01_STYLE = 1;
+
+    my $accept_language = HTTP::AcceptLanguage->new('en, da');
+    is $accept_language->match(qw/ da en /), 'da';
+    is $accept_language->match(qw/ en da /), 'en';
+};
+
+done_testing;
+

--- a/t/04_match_new.t
+++ b/t/04_match_new.t
@@ -1,0 +1,153 @@
+use strict;
+use warnings;
+use Test::More;
+
+use HTTP::AcceptLanguage;
+
+subtest 'empty' => sub {
+    subtest 'undef' => sub {
+        my $parser = HTTP::AcceptLanguage->new;
+        is($parser->match(), undef);
+
+        $parser = HTTP::AcceptLanguage->new;
+        is($parser->match(''), undef);
+    };
+    subtest 'string' => sub {
+        my $parser = HTTP::AcceptLanguage->new('');
+        is($parser->match(), undef);
+
+        $parser = HTTP::AcceptLanguage->new('');
+        is($parser->match(''), undef);
+    };
+    subtest 'has header' => sub {
+        my $parser = HTTP::AcceptLanguage->new('ja');
+        is($parser->match(), undef);
+
+        $parser = HTTP::AcceptLanguage->new('en');
+        is($parser->match(''), undef);
+    };
+};
+
+subtest 'empty header' => sub {
+    my $parser = HTTP::AcceptLanguage->new;
+    is($parser->match(qw/ en ja /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('');
+    is($parser->match(qw/ ja en /), 'ja');
+};
+
+# This behavior was changed.
+# https://github.com/yappo/p5-HTTP-AcceptLanguage/issues/1
+subtest 'flat quality' => sub {
+    my $parser = HTTP::AcceptLanguage->new('en, ja');
+    is($parser->match(qw/ en ja /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('en, ja');
+    is($parser->match(qw/ ja en /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('ja, en');
+    is($parser->match(qw/ en ja /), 'ja');
+
+    $parser = HTTP::AcceptLanguage->new('ja, en');
+    is($parser->match(qw/ ja en /), 'ja');
+};
+
+subtest 'prefix tag' => sub {
+    my $parser = HTTP::AcceptLanguage->new('en-us');
+    is($parser->match(qw/ en /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('en-us, ja');
+    is($parser->match(qw/ en ja /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('en-us, ja');
+    is($parser->match(qw/ ja en /), 'en');
+
+    subtest 'priority of full match' => sub {
+        $parser = HTTP::AcceptLanguage->new('en-us');
+        is($parser->match(qw/ en en-us /), 'en-us');
+
+        $parser = HTTP::AcceptLanguage->new('en-us');
+        is($parser->match(qw/ en-us en /), 'en-us');
+
+        $parser = HTTP::AcceptLanguage->new('en');
+        is($parser->match(qw/ en en-us /), 'en');
+
+        $parser = HTTP::AcceptLanguage->new('en');
+        is($parser->match(qw/ en-us en /), 'en');
+    };
+
+    subtest 'order by input list' => sub {
+        $parser = HTTP::AcceptLanguage->new('en-us, en');
+        is($parser->match(qw/ en en-us /), 'en-us');
+
+        $parser = HTTP::AcceptLanguage->new('en-us, en');
+        is($parser->match(qw/ en-us en /), 'en-us');
+    };
+
+    subtest 'unsupported of server side prefix tag' => sub {
+        $parser = HTTP::AcceptLanguage->new('en-us');
+        is($parser->match(qw/ en-gb /), undef);
+
+        $parser = HTTP::AcceptLanguage->new('en');
+        is($parser->match(qw/ en-gb /), undef);
+    };
+};
+
+subtest 'quality' => sub {
+    my $parser = HTTP::AcceptLanguage->new('en;q=0.1, ja');
+    is($parser->match(qw/ en ja /), 'ja');
+
+    $parser = HTTP::AcceptLanguage->new('en;q=0.1, ja;q=0.2');
+    is($parser->match(qw/ en ja /), 'ja');
+
+    $parser = HTTP::AcceptLanguage->new('en;q=0.1, en-us;q=0.1');
+    is($parser->match(qw/ en ja en-us /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('en;q=0.1, en-us;q=0.1');
+    is($parser->match(qw/ en-us ja en /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('en;q=0.1, en-us;q=0.2');
+    is($parser->match(qw/ en ja en-us /), 'en-us');
+
+    $parser = HTTP::AcceptLanguage->new('en;q=0.2, en-us;q=0.1');
+    is($parser->match(qw/ en-us ja en /), 'en');
+
+    subtest 'duplicated tag is order by quality' => sub {
+        $parser = HTTP::AcceptLanguage->new('ja;q=0.1, en;q=0.5, ja;q=0.6');
+        is($parser->match(qw/ en-us ja en /), 'ja');
+    };
+};
+
+subtest 'case sensitive' => sub {
+    my $parser = HTTP::AcceptLanguage->new('En');
+    is($parser->match(qw/ en /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('eN');
+    is($parser->match(qw/ En /), 'En');
+
+    $parser = HTTP::AcceptLanguage->new('En, zh-Tw');
+    is($parser->match(qw/ zH /), 'zH');
+
+    $parser = HTTP::AcceptLanguage->new('En, Zh-Tw');
+    is($parser->match(qw/ zH-tw /), 'zH-tw');
+};
+
+subtest 'wildcard' => sub {
+    my $parser = HTTP::AcceptLanguage->new('*');
+    is($parser->match(qw/ en ja /), 'en');
+
+    $parser = HTTP::AcceptLanguage->new('ja, *');
+    is($parser->match(qw/ en ja /), 'ja');
+
+    $parser = HTTP::AcceptLanguage->new('ja, *;q=0.3');
+    is($parser->match(qw/ en ja /), 'ja');
+
+    $parser = HTTP::AcceptLanguage->new('*, da');
+    is($parser->match(qw/ ja da /), 'ja');
+
+    $parser = HTTP::AcceptLanguage->new('*, zh-tw');
+    is($parser->match(qw/ en-US ja da /), 'en-US');
+
+};
+
+done_testing;


### PR DESCRIPTION
It is incompatible change.

If language quality is the same, the order of the input list takes from
Accept-Language header.

Quality is not set on android phone.
Sequence order of the header are used for quality.

```
my $accept_language = HTTP::AcceptLanguage->new('en, da');
$accept_language->match(qw/ da en /); # -> en
$accept_language->match(qw/ en da /); # -> en
```

It is compatible mode.

```
$HTTP::AcceptLanguage::MATCH_PRIORITY_0_01_STYLE = 1;
my $accept_language = HTTP::AcceptLanguage->new('en, da');
$accept_language->match(qw/ da en /); # -> da
$accept_language->match(qw/ en da /); # -> en
```
