### PR TITLE
Changed _parse to better reflect rfc7231, section 5.3.1

### DIFF
--- a/lib/HTTP/AcceptLanguage.pm
+++ b/lib/HTTP/AcceptLanguage.pm
@@ -30,7 +30,7 @@ sub _parse {
     my @elements;
     my %high_qualities;
     for my $element (split /,+/, $header) {
-        my($language, $quality) = $element =~ /\A($LANGUAGE_RANGE)(?:;q=($QVALUE))?\z/;
+        my($language, $quality) = $element =~ /\A($LANGUAGE_RANGE)(?:;[qQ]=($QVALUE))?\z/;
         $quality = 1 unless defined $quality;
         next unless $language && $quality > 0;
 


### PR DESCRIPTION
This provides a minor correction.
[rfc7231, section 5.3.1](https://tools.ietf.org/html/rfc7231#section-5.3.1) states that the letter 'q' is case insensitive:
> "use a common parameter, named "q" (case-insensitive)"
In light of that, I made a minor change to `_parse`